### PR TITLE
Add loadPerEnvMap implementation

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,13 +4,12 @@
 name: Test
 on:
   push:
-    branches: [ master ]
+    branches: [ master, f/*, b/* ]
   pull_request:
     branches: [ master ]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -23,4 +22,5 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - run: npm install  
     - run: npm test

--- a/README.md
+++ b/README.md
@@ -30,9 +30,40 @@ Once you've
 [configured `babel-plugin-macros`](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md)
 you can import `perenv.macro`.
 
+
+### `loadPerEnv`
+
+
+#### String Signature
+
+```javascript
+loadPerEnv(path, envar, ?value)
+```
+|Argument | Description|
+|----|----|
+|path | Node resolveable path to import (relative path or package name)|
+|envar| The environmental variable to inspect |
+|value (optional) | Conditionally load the import if the envar is equal to this value |
+
+#### Object Signature
+
+```javascript
+loadPerEnv({path, identifier}, envar, ?value)
+```
+|Argument | Description|
+|----|----|
+|path | Node resolveable path to import (relative path or package name)|
+|identifier | Identifier to use if imported (You probably want to use `loadPerEnvMap` instead of this) |
+|envar| The environmental variable to inspect |
+|value (optional) | Conditionally load the import if the envar is equal to this value |
+
+#### Usage
+
 If the environmental variable `ENABLE_MY_CONFIGURATION` is set `loadPerEnv` will transpile like this
 
 ```javascript
+// export ENABLE_MY_CONFIGURATION=1
+
 import { loadPerEnv } from "./perEnv.macro";
 loadPerEnv('./a_configuration_file.js', 'ENABLE_MY_CONFIGURATION');
 
@@ -44,6 +75,8 @@ import "./a_configuration_file.js";
 if it is not set it will transpile like this
 
 ```javascript
+// unset ENABLE_MY_CONFIGURATION
+
 import { loadPerEnv } from "./perEnv.macro";
 loadPerEnv('./a_configuration_file.js', 'ENABLE_MY_CONFIGURATION');
 
@@ -55,9 +88,8 @@ loadPerEnv('./a_configuration_file.js', 'ENABLE_MY_CONFIGURATION');
 You can also conditionally load something based on the value of the environmental variable.
 
 
-With `NODE_ENV` set to `dev`
-
 ```javascript
+// export NODE_ENV=dev
 import { loadPerEnv } from "./perEnv.macro";
 loadPerEnv('./config_dev.js', 'NODE_ENV', "dev");
 loadPerEnv('./config_prod.js', 'NODE_ENV', "production");
@@ -70,6 +102,8 @@ import "./config_dev.js";
 If you want to use the exports of a file, you can use an object as the first argument
 
 ```javascript
+// export NODE_ENV=dev
+
 import { loadPerEnv } from "./perEnv.macro";
 loadPerEnv({path: './feature.js', identifier: 'feature'}, 'NODE_ENV', "dev");
 
@@ -78,6 +112,82 @@ loadPerEnv({path: './feature.js', identifier: 'feature'}, 'NODE_ENV', "dev");
 import * as feature from "./feature.js";
 ```
 
+### `loadPerEnvMap`
+
+
+#### Signature
+
+```javascript
+loadPerEnvMap(map, envar, ?nullable = false)
+```
+|Argument | Description|
+|----|----|
+|map | A key-value map representing what is to be imported based on the value of the envar|
+|envar| The environmental variable to inspect |
+|nullable (optional) | It is safe to return null if value is not found in map |
+
+
+#### Usage
+
+
+Allows you to use a map of different imports based on the value of your envars
+
+```javascript
+// export NODE_ENV=production
+
+import { loadPerEnvMap } from "./perEnv.macro";
+loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV');
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import "./feature.js";
+```
+
+Use an assignment to declare the import namespace, handy to keep linters quiet
+
+```javascript
+// export NODE_ENV=production
+
+import { loadPerEnvMap } from "./perEnv.macro";
+const feature = loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV');
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import * as feature from "./feature.js";
+```
+
+Enable the `nullable` flag to allow for cases where the envar value may not be in the map.
+
+
+```javascript
+
+// export NODE_ENV=CI
+// or
+// unset NODE_ENV
+
+import { loadPerEnvMap } from "./perEnv.macro";
+const feature = loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV', true);
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const feature = null
+```
+
+Or in the case that no assignment is made
+
+```javascript
+
+// export NODE_ENV=CI
+// or
+// unset NODE_ENV
+
+import { loadPerEnvMap } from "./perEnv.macro";
+loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV', true);
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// Intentionally blank
+```
 
 ## Use Cases
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perenv.macro",
-  "version": "0.0.2",
+  "version": "0.0.0-semver",
   "main": "perenv.macro.js",
   "author": "Zachary Skalko",
   "license": "MIT",
@@ -11,6 +11,9 @@
     "@babel/core": "^7.11.6",
     "babel-plugin-macros": "^2.8.0",
     "jest": "^26.4.2"
+  },
+  "scripts": {
+    "test": "jest"
   },
   "description": "A Babel macro to conditionally import something based on environmental variables.",
   "repository": {

--- a/perenv.spec.js
+++ b/perenv.spec.js
@@ -9,11 +9,11 @@ function applyMacro(src) {
   }).code.trim();
 }
 
-describe("String signature", () => {
+describe("loadPerEnv: String signature", () => {
   it("should import the first argument if the env specified is defined at all", () => {
     process.env.ENABLE_A_THING = "0";
     const result = applyMacro(`
-      import { loadPerEnv } from "./perEnv.macro";
+      import { loadPerEnv } from "./perenv.macro";
       loadPerEnv('./aaa.js', 'ENABLE_A_THING');
     `);
 
@@ -23,7 +23,7 @@ describe("String signature", () => {
   it("should import the first argument if third argument is equal to the environmental variable", () => {
     process.env.ENABLE_ANOTHER_THING = "1";
     const result = applyMacro(`
-        import { loadPerEnv } from "./perEnv.macro";
+        import { loadPerEnv } from "./perenv.macro";
         loadPerEnv('./aaa.js', 'ENABLE_ANOTHER_THING', '1');
     `);
 
@@ -33,7 +33,7 @@ describe("String signature", () => {
   it("should not import the first argument if third argument does is not equal to the environmental variable", () => {
     process.env.ENABLE_ONE_MORE_THING = "1";
     const result = applyMacro(`
-        import { loadPerEnv } from "./perEnv.macro";
+        import { loadPerEnv } from "./perenv.macro";
         loadPerEnv('./src/aaa.js', 'ENABLE_ONE_MORE_THING ', '2');
     `);
 
@@ -41,11 +41,11 @@ describe("String signature", () => {
   });
 });
 
-describe("Object signature", () => {
+describe("loadPerEnv: Object signature", () => {
   it("should declare an idenfier if declared in the object signature overload", () => {
     process.env.ENABLE_A_THING = "0";
     const result = applyMacro(`
-      import { loadPerEnv } from "./perEnv.macro";
+      import { loadPerEnv } from "./perenv.macro";
       loadPerEnv({path: './ccc.js', identifier: 'thing'}, 'ENABLE_A_THING');
     `);
     expect(result).toBe(`import * as thing from "./ccc.js";`);
@@ -55,7 +55,7 @@ describe("Object signature", () => {
     process.env.ENABLE_A_THING = "0";
     expect(() =>
       applyMacro(`
-      import { loadPerEnv } from "./perEnv.macro";
+      import { loadPerEnv } from "./perenv.macro";
       const alreadyDeclared = true
       loadPerEnv({path: 'ccc.js', identifier: 'alreadyDeclared'}, 'ENABLE_A_THING');
     `)
@@ -68,7 +68,7 @@ describe("Object signature", () => {
     process.env.ENABLE_A_THING = "0";
     expect(() =>
       applyMacro(`
-      import { loadPerEnv } from "./perEnv.macro";
+      import { loadPerEnv } from "./perenv.macro";
       import alreadyDeclared from 'already.js'
       loadPerEnv({path: 'ccc.js', identifier: 'alreadyDeclared'}, 'ENABLE_A_THING');
     `)
@@ -81,12 +81,79 @@ describe("Object signature", () => {
     process.env.ENABLE_A_THING = "0";
     expect(() =>
       applyMacro(`
-      import { loadPerEnv } from "./perEnv.macro";
+      import { loadPerEnv } from "./perenv.macro";
       import { alreadyDeclared } from 'already.js'
       loadPerEnv({path: 'ccc.js', identifier: 'alreadyDeclared'}, 'ENABLE_A_THING');
     `)
     ).toThrow(
       `It seems you're trying to use an identifier that already exists with perenv.macro`
     );
+  });
+});
+
+describe("loadPerEnvMap", () => {
+  it("Should use the assignment identifier as the import namespace", () => {
+    process.env.FEATURE_VERSION = "alpha";
+
+    const result = applyMacro(`
+      import { loadPerEnvMap } from "./perenv.macro";
+      const feature = loadPerEnvMap({alpha: './aaaa.js'}, 'FEATURE_VERSION');
+    `);
+
+    expect(result.includes("import * as feature ")).toBe(true);
+  });
+
+  it("Should throw if the envar value is not found in the env map", () => {
+    process.env.FEATURE_VERSION = "alpha";
+
+    expect(() =>
+      applyMacro(`
+        import { loadPerEnvMap } from "./perenv.macro";
+        const feature = loadPerEnvMap({beta: './aaaa.js'}, 'FEATURE_VERSION');
+      `)
+    ).toThrow("Entry not found in loadPerEnvMap, FEATURE_VERSION:alpha");
+  });
+
+  it("Should assign null if env var is not found in map and nullable flag is set to true", () => {
+    process.env.FEATURE_VERSION = "alpha";
+
+    const result = applyMacro(`
+      import { loadPerEnvMap } from "./perenv.macro";
+      const feature = loadPerEnvMap({beta: './aaaa.js'}, 'FEATURE_VERSION', true);
+    `);
+
+    expect(result).toEqual("const feature = null;");
+  });
+
+  it("Should remove statement without an assignment if env var is not found in map and nullable flag is set to true", () => {
+    process.env.FEATURE_VERSION = "alpha";
+
+    const result = applyMacro(`
+      import { loadPerEnvMap } from "./perenv.macro";
+      loadPerEnvMap({beta: './aaaa.js'}, 'FEATURE_VERSION', true);
+    `);
+
+    expect(result).toEqual("");
+  });
+
+  it("Should not use an import namespace if there is no assignment", () => {
+    process.env.FEATURE_VERSION = "alpha";
+
+    const result = applyMacro(`
+      import { loadPerEnvMap } from "./perenv.macro";
+      loadPerEnvMap({alpha: './aaaa.js'}, 'FEATURE_VERSION');
+    `);
+    expect(result).toEqual(`import "./aaaa.js";`);
+  });
+
+  it("Should use an import namespace if there is an assignment", () => {
+    process.env.FEATURE_VERSION = "alpha";
+
+    const result = applyMacro(`
+      import { loadPerEnvMap } from "./perenv.macro";
+      const feature = loadPerEnvMap({alpha: './aaaa.js'}, 'FEATURE_VERSION');
+    `);
+
+    expect(result).toEqual(`import * as feature from "./aaaa.js";`);
   });
 });


### PR DESCRIPTION
Addresses #1 

Adds a new method to load by a map of values.

From the updated readme:


<strike>

### `loadPerEnvMap`

Allows you to use a map of different imports based on the value of your envars

```javascript
import { loadPerEnvMap } from "./perEnv.macro";
loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV');

      ↓ ↓ ↓ ↓ ↓ ↓

import "./feature.js";
```

Use an assignment to declare the import namespace, handy to keep linters quiet

```javascript
import { loadPerEnvMap } from "./perEnv.macro";
const feature = loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV');

      ↓ ↓ ↓ ↓ ↓ ↓

import * as feature from "./feature.js";
```

Enable the `nullable` flag to allow for cases where the envar value may not be in the map.


```javascript

// NODE_ENV=CI
import { loadPerEnvMap } from "./perEnv.macro";
const feature = loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV', true);

      ↓ ↓ ↓ ↓ ↓ ↓

const feature = null
```

Or in the case that no assignment is made

```javascript

// NODE_ENV=CI
import { loadPerEnvMap } from "./perEnv.macro";
const feature = loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV', true);

      ↓ ↓ ↓ ↓ ↓ ↓

// Intentionally blank
```

</strike>

### `loadPerEnvMap`


#### Signature

```javascript
loadPerEnvMap(map, envar, ?nullable = false)
```
|Argument | Description|
|----|----|
|map | A key-value map representing what is to be imported based on the value of the envar|
|envar| The environmental variable to inspect |
|nullable (optional) | It is safe to return null if value is not found in map |


#### Usage


Allows you to use a map of different imports based on the value of your envars

```javascript
// export NODE_ENV=production

import { loadPerEnvMap } from "./perEnv.macro";
loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV');

      ↓ ↓ ↓ ↓ ↓ ↓

import "./feature.js";
```

Use an assignment to declare the import namespace, handy to keep linters quiet

```javascript
// export NODE_ENV=production

import { loadPerEnvMap } from "./perEnv.macro";
const feature = loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV');

      ↓ ↓ ↓ ↓ ↓ ↓

import * as feature from "./feature.js";
```

Enable the `nullable` flag to allow for cases where the envar value may not be in the map.


```javascript

// export NODE_ENV=CI
// or
// unset NODE_ENV

import { loadPerEnvMap } from "./perEnv.macro";
const feature = loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV', true);

      ↓ ↓ ↓ ↓ ↓ ↓

const feature = null
```

Or in the case that no assignment is made

```javascript

// export NODE_ENV=CI
// or
// unset NODE_ENV

import { loadPerEnvMap } from "./perEnv.macro";
loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV', true);

      ↓ ↓ ↓ ↓ ↓ ↓

// Intentionally blank
```