### PR TITLE
Fixes README example usage consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If the environmental variable `ENABLE_MY_CONFIGURATION` is set `loadPerEnv` will
 ```javascript
 // export ENABLE_MY_CONFIGURATION=1
 
-import { loadPerEnv } from "./perEnv.macro";
+import { loadPerEnv } from "perEnv.macro";
 loadPerEnv('./a_configuration_file.js', 'ENABLE_MY_CONFIGURATION');
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -77,7 +77,7 @@ if it is not set it will transpile like this
 ```javascript
 // unset ENABLE_MY_CONFIGURATION
 
-import { loadPerEnv } from "./perEnv.macro";
+import { loadPerEnv } from "perEnv.macro";
 loadPerEnv('./a_configuration_file.js', 'ENABLE_MY_CONFIGURATION');
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -90,7 +90,7 @@ You can also conditionally load something based on the value of the environmenta
 
 ```javascript
 // export NODE_ENV=dev
-import { loadPerEnv } from "./perEnv.macro";
+import { loadPerEnv } from "perEnv.macro";
 loadPerEnv('./config_dev.js', 'NODE_ENV', "dev");
 loadPerEnv('./config_prod.js', 'NODE_ENV', "production");
 
@@ -104,7 +104,7 @@ If you want to use the exports of a file, you can use an object as the first arg
 ```javascript
 // export NODE_ENV=dev
 
-import { loadPerEnv } from "./perEnv.macro";
+import { loadPerEnv } from "perEnv.macro";
 loadPerEnv({path: './feature.js', identifier: 'feature'}, 'NODE_ENV', "dev");
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -135,7 +135,7 @@ Allows you to use a map of different imports based on the value of your envars
 ```javascript
 // export NODE_ENV=production
 
-import { loadPerEnvMap } from "./perEnv.macro";
+import { loadPerEnvMap } from "perEnv.macro";
 loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV');
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -148,7 +148,7 @@ Use an assignment to declare the import namespace, handy to keep linters quiet
 ```javascript
 // export NODE_ENV=production
 
-import { loadPerEnvMap } from "./perEnv.macro";
+import { loadPerEnvMap } from "perEnv.macro";
 const feature = loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV');
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -165,7 +165,7 @@ Enable the `nullable` flag to allow for cases where the envar value may not be i
 // or
 // unset NODE_ENV
 
-import { loadPerEnvMap } from "./perEnv.macro";
+import { loadPerEnvMap } from "perEnv.macro";
 const feature = loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV', true);
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -181,7 +181,7 @@ Or in the case that no assignment is made
 // or
 // unset NODE_ENV
 
-import { loadPerEnvMap } from "./perEnv.macro";
+import { loadPerEnvMap } from "perEnv.macro";
 loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV', true);
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -194,7 +194,7 @@ loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV',
 ### Enable `msw` in testing environments without adding it to source at build time
 ```javascript
 // index.js
-import { loadPerEnv } from "./perEnv.macro";
+import { loadPerEnv } from "perEnv.macro";
 loadPerEnv('mocks.js', 'ENABLE_MOCKS');
 ```
 
@@ -202,7 +202,7 @@ loadPerEnv('mocks.js', 'ENABLE_MOCKS');
 
 ```javascript
 // index.js
-import { loadPerEnv } from "./perEnv.macro";
+import { loadPerEnv } from "perEnv.macro";
 loadPerEnv('mocks.js', 'ISOLATED_MICROFRONTEND');
 
 // mocks.js
@@ -217,7 +217,7 @@ window.globalStore = {
 
 ```javascript
 // index.js
-import { loadPerEnv } from "./perEnv.macro";
+import { loadPerEnv } from "perEnv.macro";
 loadPerEnv('polyfills.js', 'NODE_ENV', 'production');
 ```
 
@@ -226,7 +226,7 @@ loadPerEnv('polyfills.js', 'NODE_ENV', 'production');
 
 ```javascript
 // index.js
-import { loadPerEnv } from "./perEnv.macro";
+import { loadPerEnv } from "perEnv.macro";
 loadPerEnv({path: 'new_feature.js', identifier: 'feature'}, 'FEATURE_FLAG_X', 'enabled');
 loadPerEnv({path: 'old_feature.js', identifier: 'feature'}, 'FEATURE_FLAG_X', 'disabled');
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If the environmental variable `ENABLE_MY_CONFIGURATION` is set `loadPerEnv` will
 ```javascript
 // export ENABLE_MY_CONFIGURATION=1
 
-import { loadPerEnv } from "perEnv.macro";
+import { loadPerEnv } from "perenv.macro";
 loadPerEnv('./a_configuration_file.js', 'ENABLE_MY_CONFIGURATION');
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -77,7 +77,7 @@ if it is not set it will transpile like this
 ```javascript
 // unset ENABLE_MY_CONFIGURATION
 
-import { loadPerEnv } from "perEnv.macro";
+import { loadPerEnv } from "perenv.macro";
 loadPerEnv('./a_configuration_file.js', 'ENABLE_MY_CONFIGURATION');
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -90,7 +90,7 @@ You can also conditionally load something based on the value of the environmenta
 
 ```javascript
 // export NODE_ENV=dev
-import { loadPerEnv } from "perEnv.macro";
+import { loadPerEnv } from "perenv.macro";
 loadPerEnv('./config_dev.js', 'NODE_ENV', "dev");
 loadPerEnv('./config_prod.js', 'NODE_ENV', "production");
 
@@ -104,7 +104,7 @@ If you want to use the exports of a file, you can use an object as the first arg
 ```javascript
 // export NODE_ENV=dev
 
-import { loadPerEnv } from "perEnv.macro";
+import { loadPerEnv } from "perenv.macro";
 loadPerEnv({path: './feature.js', identifier: 'feature'}, 'NODE_ENV', "dev");
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -135,7 +135,7 @@ Allows you to use a map of different imports based on the value of your envars
 ```javascript
 // export NODE_ENV=production
 
-import { loadPerEnvMap } from "perEnv.macro";
+import { loadPerEnvMap } from "perenv.macro";
 loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV');
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -148,7 +148,7 @@ Use an assignment to declare the import namespace, handy to keep linters quiet
 ```javascript
 // export NODE_ENV=production
 
-import { loadPerEnvMap } from "perEnv.macro";
+import { loadPerEnvMap } from "perenv.macro";
 const feature = loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV');
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -165,7 +165,7 @@ Enable the `nullable` flag to allow for cases where the envar value may not be i
 // or
 // unset NODE_ENV
 
-import { loadPerEnvMap } from "perEnv.macro";
+import { loadPerEnvMap } from "perenv.macro";
 const feature = loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV', true);
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -181,7 +181,7 @@ Or in the case that no assignment is made
 // or
 // unset NODE_ENV
 
-import { loadPerEnvMap } from "perEnv.macro";
+import { loadPerEnvMap } from "perenv.macro";
 loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV', true);
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -194,7 +194,7 @@ loadPerEnvMap({dev: './new_feature.js', production: './feature.js'}, 'NODE_ENV',
 ### Enable `msw` in testing environments without adding it to source at build time
 ```javascript
 // index.js
-import { loadPerEnv } from "perEnv.macro";
+import { loadPerEnv } from "perenv.macro";
 loadPerEnv('mocks.js', 'ENABLE_MOCKS');
 ```
 
@@ -202,7 +202,7 @@ loadPerEnv('mocks.js', 'ENABLE_MOCKS');
 
 ```javascript
 // index.js
-import { loadPerEnv } from "perEnv.macro";
+import { loadPerEnv } from "perenv.macro";
 loadPerEnv('mocks.js', 'ISOLATED_MICROFRONTEND');
 
 // mocks.js
@@ -217,7 +217,7 @@ window.globalStore = {
 
 ```javascript
 // index.js
-import { loadPerEnv } from "perEnv.macro";
+import { loadPerEnv } from "perenv.macro";
 loadPerEnv('polyfills.js', 'NODE_ENV', 'production');
 ```
 
@@ -226,7 +226,7 @@ loadPerEnv('polyfills.js', 'NODE_ENV', 'production');
 
 ```javascript
 // index.js
-import { loadPerEnv } from "perEnv.macro";
+import { loadPerEnv } from "perenv.macro";
 loadPerEnv({path: 'new_feature.js', identifier: 'feature'}, 'FEATURE_FLAG_X', 'enabled');
 loadPerEnv({path: 'old_feature.js', identifier: 'feature'}, 'FEATURE_FLAG_X', 'disabled');
 ```


### PR DESCRIPTION
I noticed while copy and pasting then adapting the readme examples that there were `./` in the

```
import { loadPerEnv } from "./perEnv.macro";	
```

examples.