### PR TITLE
Support string literal keys for EnvMap

### DIFF
--- a/perenv.macro.js
+++ b/perenv.macro.js
@@ -27,7 +27,7 @@ function loadPerEnvMacro({ state, babel, references }) {
       nullableReference.type === "BooleanLiteral" &&
       nullableReference.value;
 
-    const envMapKeys = envMapReference.properties.map((p) => p.key.name);
+    const envMapKeys = envMapReference.properties.map((p) => p.key.name || p.key.value);
     const envKey = envKeyReference.value;
 
     if (!envMapKeys.includes(process.env[envKey]) && !nullable) {
@@ -37,7 +37,7 @@ function loadPerEnvMacro({ state, babel, references }) {
     }
 
     const propertyReference = envMapReference.properties.find(
-      (p) => p.key.name === process.env[envKey]
+      (p) => (p.key.name || p.key.value) === process.env[envKey]
     );
 
     if (!propertyReference && nullable) {

--- a/perenv.macro.js
+++ b/perenv.macro.js
@@ -1,5 +1,16 @@
 const { createMacro } = require("babel-plugin-macros");
 
+function extractKeyName(property) {
+  const { key } = property;
+  if (key.type === 'StringLiteral') {
+    return key.value;
+  }
+  if (key.name) {
+    return key.name;
+  }
+  throw new Error(`Unsupported key in loadPerEnvMap`);
+}
+
 function loadPerEnvMacro({ state, babel, references }) {
   const t = babel.types;
   const program = state.file.path;
@@ -27,7 +38,7 @@ function loadPerEnvMacro({ state, babel, references }) {
       nullableReference.type === "BooleanLiteral" &&
       nullableReference.value;
 
-    const envMapKeys = envMapReference.properties.map((p) => p.key.name || p.key.value);
+    const envMapKeys = envMapReference.properties.map(extractKeyName);
     const envKey = envKeyReference.value;
 
     if (!envMapKeys.includes(process.env[envKey]) && !nullable) {
@@ -37,7 +48,7 @@ function loadPerEnvMacro({ state, babel, references }) {
     }
 
     const propertyReference = envMapReference.properties.find(
-      (p) => (p.key.name || p.key.value) === process.env[envKey]
+      (p) => extractKeyName(p) === process.env[envKey]
     );
 
     if (!propertyReference && nullable) {

--- a/perenv.spec.js
+++ b/perenv.spec.js
@@ -103,6 +103,17 @@ describe("loadPerEnvMap", () => {
     expect(result.includes("import * as feature ")).toBe(true);
   });
 
+  it("Should support string literal keys", () => {
+    process.env.FEATURE_VERSION = "alpha";
+
+    const result = applyMacro(`
+      import { loadPerEnvMap } from "./perenv.macro";
+      const feature = loadPerEnvMap({'alpha': './aaaa.js'}, 'FEATURE_VERSION');
+    `);
+
+    expect(result.includes("import * as feature ")).toBe(true);
+  });
+
   it("Should throw if the envar value is not found in the env map", () => {
     process.env.FEATURE_VERSION = "alpha";
 


### PR DESCRIPTION
An `Entry not found in loadPerEnvMap` error occured when string literals are used as keys of the envMap:

```js
loadPerEnvMap(
  {
    'us-w1': 'A',
    'us-w2': 'B',
  },
  'REGION'
)
```

The key node was parsed as a `StringLiteral` :

```
 key: Node {
      type: 'StringLiteral',
      start: 330,
      end: 339,
      loc: [SourceLocation],
      extra: [Object],
      value: 'us-w1',
      ...
    },
```